### PR TITLE
First pass at adding error handling to the _get() method

### DIFF
--- a/cruddy/__init__.py
+++ b/cruddy/__init__.py
@@ -93,8 +93,18 @@ class CRUD(object):
             response['status'] = 'error'
             response['message'] = 'get requires an id'
         else:
-            item = self._table.get_item(Key={'id': id})['Item']
-            response['data'] = self._replace_decimals(item)
+            try:
+                LOG.debug('Getting item with id: %s', id)
+                response = self._table.get_item(Key={'id': id})
+                LOG.debug(response)
+                item = response['Item']
+                response['data'] = self._replace_decimals(item)
+            except botocore.exceptions.ClientError as e:
+                LOG.debug(e)
+                response['status'] = 'error'
+                response['message'] = e.response['Error'].get('Message')
+                response['code'] = e.response['Error'].get('Code')
+                response['type'] = e.response['Error'].get('Type')
 
     def handler(self, item, operation):
         response = {'status': 'success'}


### PR DESCRIPTION
My main goal here was to give as much information back about what error occurred as possible.

My secondary goal was if someone wanted to see the raw response, that should be possible by setting the logging level to DEBUG.

Having said that, the top of the file explicitly sets it to INFO. Should it?

Also, should the LOG like be this?

```
LOG = logging.getLogger(__name__)
```

My understanding is that give the logger the name of the module and can then addressed and tuned according to the user of this library.
