### PR TITLE
Make encryption optional for update

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ the ``flatten`` method
  'status': 'success'}
  >>>
  ```
- 
+
 ## CRUD operations
 
 The CRUD object supports the following operations.  Note that depending on the
@@ -190,9 +190,13 @@ Creates a new item.  You pass in an item containing initial values.  Any
 attribute names defined in ``prototype`` that are missing from the item will be
 added using the default value defined in ``prototype``.
 
-### update(*item*)
+### update(*item*, *encrypt=True*)
 
-Updates the item based on the current values of the dictionary passed in.
+Updates the item based on the current values of the dictionary passed in. If
+the ``encrypt`` param is True (the default), encrypted attributes in ``item``
+are encrypted. To prevent double-encrypting when using ``list`` or ``get``
+without ``decrypt=True``, you can specify ``encrypt=False`` and the item will
+be stored verbatim.
 
 ### delete(*id*)
 
@@ -358,4 +362,3 @@ $ cruddy --lambda-fn fiebaz list
 ```
 
 where ``fiebaz`` is the name of your Lambda handler.
-

--- a/cruddy/__init__.py
+++ b/cruddy/__init__.py
@@ -329,7 +329,7 @@ class CRUD(object):
         response.prepare()
         return response
 
-    def update(self, item, **kwargs):
+    def update(self, item, encrypt=True, **kwargs):
         """
         Updates the item based on the current values of the dictionary passed
         in.
@@ -337,7 +337,8 @@ class CRUD(object):
         response = self._new_response()
         if self._check_supported_op('update', response):
             if self._prototype_handler.check(item, 'update', response):
-                self._encrypt(item)
+                if encrypt:
+                    self._encrypt(item)
                 params = {'Item': item}
                 self._call_ddb_method(self.table.put_item,
                                       params, response)

--- a/cruddy/lambdaclient.py
+++ b/cruddy/lambdaclient.py
@@ -106,6 +106,8 @@ class LambdaClient(object):
     def update(self, item, **kwargs):
         data = {'operation': 'update',
                 'item': item}
+        encrypt = kwargs.get('encrypt', True)
+        data['encrypt'] = encrypt
         data.update(kwargs)
         return self.invoke(data)
 

--- a/cruddy/scripts/cli.py
+++ b/cruddy/scripts/cli.py
@@ -190,11 +190,16 @@ def create(handler, item_document):
 
 
 @cli.command()
+@click.option(
+    '--encrypt/--no-encrypt',
+    default=True,
+    help='Encrypt any encrypted attributes')
 @click.argument('item_document', type=click.File('rb'))
 @pass_handler
 def update(handler, item_document):
     """Update an item from a JSON document"""
     data = {'operation': 'update',
+            'encrypt': encrypt,
             'item': json.load(item_document)}
     handler.invoke(data)
 


### PR DESCRIPTION
As suggested in Issue #36, this adds a way to optionally disable encryption when updating an item
